### PR TITLE
Adding landscape support

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,8 @@ async function _render (string, stringIsHTML = true, opts = {}) {
    const renderOpts = {
       format: opts.format || _defaultRenderOpts.format,
       margin: margin,
-      scale: opts.scale || _defaultRenderOpts.scale
+      scale: opts.scale || _defaultRenderOpts.scale,
+      landscape: opts.landscape
    };
    // Run puppetteer in temporary directory, which is deleted afterwards
    return WithTempDir(async (tmpdir) => {


### PR DESCRIPTION
Allowing the user to pass the landscape flag through the options object. Maintains the landscape flag key from puppeteer (ie landscape and not isLandscape)